### PR TITLE
[ feat / SCRUM-58 ] 정적 페이지 서빙 구조 구성

### DIFF
--- a/Sandwich/docker-compose.yml
+++ b/Sandwich/docker-compose.yml
@@ -63,6 +63,8 @@ services:
       - "80:80"
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf
+      - ../front/build:/app
+      - ./public:/app/public   # 사용자 프로젝트 정적파일 저장소 들어갈 곳
     depends_on:
       - app
     networks:

--- a/Sandwich/nginx.conf
+++ b/Sandwich/nginx.conf
@@ -8,11 +8,26 @@ http {
 
   server {
     listen 80;
+    server_name sandwich.com;
 
+    # 1. API 요청 → Spring으로 프록시
     location / {
       proxy_pass http://app;
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    # 2. 메인 홈페이지 → 정적 파일 (예: /app/main/index.html)
+    location = / {
+      root /app;  # 정적 파일 루트
+      index index.html;
+      try_files /index.html =404;
+    }
+
+    # 3. 사용자 포트폴리오 → 정적 콘텐츠로 매핑
+    location ~ ^/([^/]+)/([^/]+)$ {
+      root /app/public;
+      try_files /$1/$2/index.html =404;
     }
   }
 }


### PR DESCRIPTION
[ feat / SCRUM-58 ] 정적 페이지 서빙 구조 구성
사용자가 업로드한 프로젝트를 실제 페이지처럼 보여주기 위한 정적 콘텐츠 서빙 구조 마련 및 자동 배포 준비
https://hyeonjujo999.atlassian.net/browse/SCRUM-58